### PR TITLE
Adding support for backpay during rotational play.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Career Pay on Payday
 
-This mod stops households from immediately receiving salary each day. Instead, pay is deferred to next Friday household
-is active.
+Actions:
+* This mod stops households from immediately receiving salary each day. Instead, pay is deferred to next Friday
+  household is active.
+* When loading into a household, check to see if any members have salary payments from a previous pay period (simply 
+  check if any days in storage greater than current day, ignoring days greater than payday).
 
 This repository requires [Sims 4 Community Library](https://github.com/ColonolNutty/Sims4CommunityLibrary) API to 
 compile. Instructions can be found in `Libraries/S4CL`.

--- a/Scripts/pay_on_payday_scripts/PayControl/payday_alarms.py
+++ b/Scripts/pay_on_payday_scripts/PayControl/payday_alarms.py
@@ -1,15 +1,11 @@
-from string import Template
-
+from pay_on_payday_scripts.PayControl.payment_handler import PaymentHandler
 from pay_on_payday_scripts.modinfo import ModInfo, ModLogger
-from pay_on_payday_scripts.persistence.payday_data_storage import PaydaySimDataStorage
+from pay_on_payday_scripts.notifications.payday_notifications import PaydayNotifications
 from pay_on_payday_scripts.utils.common_alarm_handle import CommonAlarmHandle
 from pay_on_payday_scripts.utils.common_alarm_utils import SSCommonAlarmUtils
 from pay_on_payday_scripts.utils.extra_time_utils import ExtraTimeUtils
-from protocolbuffers import Consts_pb2
-from sims4communitylib.notifications.common_basic_notification import CommonBasicNotification
 from sims4communitylib.utils.common_time_utils import CommonTimeUtils
 from sims4communitylib.utils.sims.common_household_utils import CommonHouseholdUtils
-from sims4communitylib.utils.sims.common_sim_utils import CommonSimUtils
 
 
 class PDAlarmHandler:
@@ -36,28 +32,10 @@ class PDAlarmHandler:
         ModLogger.info("Running should payout check on {}.".format(cur_day))
         if cur_day != 'Fri':
             return
-        active_sim_info = CommonSimUtils.get_active_sim_info()
         active_household = CommonHouseholdUtils.get_active_household()
-        total_payout = 0
-        for sim in active_household.get_humans_gen():
-            sim_paydayinfo = PaydaySimDataStorage(sim)
-            if sim_paydayinfo is not None:
-                total_payout += sum(sim_paydayinfo.weekday_payments.values())
-                sim_paydayinfo.weekday_payments = dict()
-        # TODO: iterate through all stored sims, group by household, then payout by household
-        # currently only pays out active household, rotational play would be an issue.
-        ModLogger.info(Template("Total to date: $total").substitute(
-            total=total_payout
-        ))
-        active_household.funds.add(
-            total_payout,
-            Consts_pb2.TELEMETRY_MONEY_CAREER,
-            active_sim_info)
-        notification = CommonBasicNotification(
-            "It's Payday!",
-            "The {} household has earned {} this week.".format(active_household.name, total_payout)
-        )
-        notification.show()
+        total_payout = PaymentHandler.payout_earned(active_household)
+        if total_payout != 0:
+            PaydayNotifications.notify_payday(active_household.name, total_payout)
 
 # I imagine I might need to solve the case of something like "Manage Households", singleton should help me here
 singleton_PDAlarmHandler = PDAlarmHandler()

--- a/Scripts/pay_on_payday_scripts/PayControl/payday_listeners.py
+++ b/Scripts/pay_on_payday_scripts/PayControl/payday_listeners.py
@@ -1,27 +1,16 @@
-from typing import Optional, Any, Tuple
+from typing import Any, Tuple
 
-import services
 from careers.career_base import CareerBase
 from pay_on_payday_scripts.PayControl.payday_alarms import singleton_PDAlarmHandler
-from pay_on_payday_scripts.persistence.payday_data_storage import PaydaySimDataStorage
+from pay_on_payday_scripts.PayControl.payment_handler import PaymentHandler
+from pay_on_payday_scripts.notifications.payday_notifications import PaydayNotifications
 from pay_on_payday_scripts.modinfo import ModInfo, ModLogger
-from pay_on_payday_scripts.utils.extra_time_utils import ExtraTimeUtils
 from sims4communitylib.events.event_handling.common_event_registry import CommonEventRegistry
 from sims4communitylib.events.zone_spin.events.zone_late_load import S4CLZoneLateLoadEvent
 from sims4communitylib.utils.common_injection_utils import CommonInjectionUtils
-from string import Template
 
 from sims4communitylib.utils.common_time_utils import CommonTimeUtils
-
-"""
-Logic:
-
-1. Search if there is already a valid romance; ignore
-2. Search if there is available romance ( has_positive_romantic_combo_relationship_bit_with, :
-    * if relationship high enough, trigger relationship bit
-3. otherwise,
-    * search change relationship up/down 
-"""
+from sims4communitylib.utils.sims.common_household_utils import CommonHouseholdUtils
 
 
 class PaydayListeners:
@@ -33,31 +22,25 @@ class PaydayListeners:
             Listens for Career rewards, undoes the simoleon earnings and stores them on the sim for future payment
             NOTE: This only accounts for salary payments, promotion payments are separately handled.
         """
+        ModLogger.info("Salary event was captured. Attempting to clear earnings.")
         from protocolbuffers import Consts_pb2
         (original_pay, pto_delta) = original(*_args, **_kwargs)
         # Store original pay to total, return 0 if not payday else return total and zero total out
         orig_self = _args[0]
-        orig_self._sim_info.household.funds.try_remove(
-            original_pay,
-            Consts_pb2.TELEMETRY_MONEY_CAREER,
-            orig_self._get_sim())
-        cur_day = CommonTimeUtils.get_current_day()
-        cur_day_name = ExtraTimeUtils.get_dayname_from_simday(CommonTimeUtils.get_current_day())
-        sim_info = orig_self._sim_info
-        sim_storage: Optional[PaydaySimDataStorage] = PaydaySimDataStorage(sim_info)
-        if sim_storage is None:
-            raise RuntimeError('Failed to locate a data manager for {} Sim Data')
-        ModLogger.info(Template("Payday ate $money_amount simoleons for $sim_name on $day.").substitute(
-            money_amount=original_pay,
-            sim_name=sim_info.full_name,
-            day=cur_day_name
-        ))
-        sim_storage.add_weekday_payment(cur_day, original_pay)
-
+        PaymentHandler.withhold_salary(orig_self._get_sim(), CommonTimeUtils.get_current_day(), original_pay)
         return (original_pay, pto_delta)
 
     @staticmethod
     @CommonEventRegistry.handle_events(ModInfo.get_identity())
     def _show_loaded_notification_when_loaded(event_data: S4CLZoneLateLoadEvent):
         ModLogger.info("successfully loaded.")
+        PaydayListeners._pay_unpaid_backpay()
         singleton_PDAlarmHandler.create_payout_check_alarm()
+
+    @staticmethod
+    def _pay_unpaid_backpay():
+        weekday = CommonTimeUtils.get_day_of_week()
+        active_household = CommonHouseholdUtils.get_active_household()
+        if PaymentHandler.unpaid_backpay(active_household, weekday):
+            reward = PaymentHandler.payout_earned(active_household)
+            PaydayNotifications.notify_backpay(active_household.name, reward)

--- a/Scripts/pay_on_payday_scripts/PayControl/payment_handler.py
+++ b/Scripts/pay_on_payday_scripts/PayControl/payment_handler.py
@@ -1,0 +1,82 @@
+from typing import Optional
+
+from string import Template
+from pay_on_payday_scripts.modinfo import ModLogger
+from pay_on_payday_scripts.persistence.payday_data_storage import PaydaySimDataStorage
+from pay_on_payday_scripts.utils.extra_time_utils import ExtraTimeUtils
+from protocolbuffers import Consts_pb2
+from sims.household import Household
+from sims.sim_info import SimInfo
+from sims4communitylib.utils.common_time_utils import CommonTimeUtils
+
+
+class PaymentHandler:
+    @staticmethod
+    def payout_earned(household: Household):
+        total_payout: int = 0
+        any_household_sim: SimInfo = None
+        for sim in household.get_humans_gen():
+            sim_paydayinfo = PaydaySimDataStorage(sim)
+            if sim_paydayinfo is not None:
+                any_household_sim = sim
+                total_payout += sum(sim_paydayinfo.weekday_payments.values())
+                sim_paydayinfo.weekday_payments = dict()
+        ModLogger.info(Template("Total to date: $total").substitute(
+            total=total_payout
+        ))
+        if total_payout > 0:
+            household.funds.add(
+                total_payout,
+                Consts_pb2.TELEMETRY_MONEY_CAREER,
+                any_household_sim)
+        elif total_payout < 0:
+            household.funds.try_remove(
+                total_payout,
+                Consts_pb2.TELEMETRY_MONEY_CAREER,
+                any_household_sim)
+
+        return total_payout
+
+    @staticmethod
+    def withhold_salary(sim: SimInfo, day: int, pay_amount: int):
+        """
+        Removes <pay_amount> in simoleons from <sim> and adds to storage keyed to <day>
+        :param sim: sim to withhold salary from
+        :param day: day to attach salary to
+        :param pay_amount:
+        :return:
+        """
+        # Store original pay to total, return 0 if not payday else return total and zero total out
+        sim.household.funds.try_remove(
+            pay_amount,
+            Consts_pb2.TELEMETRY_MONEY_CAREER,
+            sim)
+        cur_day = CommonTimeUtils.get_current_day()
+        cur_day_name = ExtraTimeUtils.get_dayname_from_simday(day)
+        sim_storage: Optional[PaydaySimDataStorage] = PaydaySimDataStorage(sim)
+        if sim_storage is None:
+            raise RuntimeError('Failed to locate a data manager for {} Sim Data')
+        ModLogger.info(Template("Payday ate $money_amount simoleons for $sim_name on $day.").substitute(
+            money_amount=pay_amount,
+            sim_name=sim.full_name,
+            day=cur_day_name
+        ))
+        sim_storage.add_weekday_payment(cur_day, pay_amount)
+
+    @staticmethod
+    def unpaid_backpay(household: Household, current_day: int):
+        """
+        Checks if <household> has any payments in storage to be considered "backpay"
+        In essence, did household not receive payment over previous pay period (household missed Friday rollover)
+        :param household:
+        :param current_day:
+        :return:
+        """
+        for sim in household.get_humans_gen():
+            sim_paydayinfo: PaydaySimDataStorage = PaydaySimDataStorage(sim)
+            if sim_paydayinfo is not None:
+                # we mod 6 as we pay on Friday, so we don't care if we never care if we haven't paid Saturday's
+                if len(sim_paydayinfo.weekday_payments.keys()) > 0 and\
+                        (max(map(int, sim_paydayinfo.weekday_payments.keys())) % 6) > current_day:
+                    return True
+        return False

--- a/Scripts/pay_on_payday_scripts/notifications/payday_notifications.py
+++ b/Scripts/pay_on_payday_scripts/notifications/payday_notifications.py
@@ -1,12 +1,8 @@
-import sims4.log
-
-from pay_on_payday_scripts.modinfo import ModInfo
+from pay_on_payday_scripts.modinfo import ModInfo, ModLogger
 from sims4communitylib.notifications.common_basic_notification import CommonBasicNotification
 
-logger = sims4.log.Logger('Payday')
 
-
-class PayDayNotifications:
+class PaydayNotifications:
     """
         A class that holds all mod's notifications.
         This is allows consolidation of visible text towards potential I18N/L10N.
@@ -14,9 +10,18 @@ class PayDayNotifications:
 
     @staticmethod
     def notify_payday(household_name: str, payout: int) -> None:
-        ModInfo.info("Payday has been announced.")
+        ModLogger.info("Payday has been announced.")
         notification = CommonBasicNotification(
             "It's Payday!",
             "The {} household has earned {} this week.".format(household_name, payout)
+        )
+        notification.show()
+
+    @staticmethod
+    def notify_backpay(household_name: str, payout: int) -> None:
+        ModLogger.info("Backpay has been announced.")
+        notification = CommonBasicNotification(
+            "Bank has rewarded salary back pay",
+            "The {} household earned {} last pay period.".format(household_name, payout)
         )
         notification.show()


### PR DESCRIPTION
When loading into a household, check to see if any members have salary
payments from a previous pay period (simply check if any days in storage
greater than current day).

- Minor file cleanup, not much better organization, but at least things are slightly more isolated.